### PR TITLE
feat: Implement resilience handling for MVG API calls in coordinator

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Daniel Potthast
+Copyright (c) 2026 Daniel Potthast
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,15 +8,21 @@
 
 # HACS-Plugin: MVG
 
-The `mvg` sensor will give you the departure time of the next bus, tram, subway, or train at the next station or stop in the Munich public transport network. Additional details such as the line number and destination are present in the attributes.
+The `mvg` sensor will give you the departure time of the next bus, tram, subway, or train at the next station or stop in the Munich public transport network. Additional details such as the line number and destination are present in the attributes, including a `messages` attribute with current incidents affecting the station's lines.
 
 ## Credits
 
-I've copied and adapted the code from [fellnerse](https://github.com/fellnerse)’s [PR](https://github.com/home-assistant/core/pull/97271).
+I've copied and adapted the code from [fellnerse](https://github.com/fellnerse)’s [PR](https://github.com/home-assistant/core/pull/97271). Departures, stations and incident messages are fetched using the [mvg](https://pypi.org/project/mvg/) PyPI package.
 
-## Configuration
+## Setup
 
-To enable this sensor, add the following lines to your `configuration.yaml` file:
+Add the integration via **Settings → Devices & Services → Add Integration → MVG** and search for your station. Destinations, lines, modes of transport, time offset and number of departures can be adjusted afterwards via the integration's **Configure** options.
+
+## Configuration via YAML (deprecated)
+
+Configuring via `configuration.yaml` is deprecated but still supported for migration: existing entries are automatically imported as UI config entries on startup, after which the YAML block can be removed.
+
+To enable this sensor via YAML, add the following lines to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/custom_components/mvg/api_resilience.py
+++ b/custom_components/mvg/api_resilience.py
@@ -1,0 +1,89 @@
+"""Retry, backoff and rate-limit handling around the mvg package's API calls.
+
+The mvg package (https://pypi.org/project/mvg/) wraps every HTTP failure into a
+plain ``MvgApiError`` with only a text message, so the HTTP status code isn't
+available in a structured way and retry/backoff can't be added inside the
+package itself. This module adds that resilience layer around calls to it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import re
+import time
+from typing import Any, Callable, Coroutine, TypeVar
+
+from mvg import MvgApiError
+
+_LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_STATUS_RE = re.compile(r"\((\d{3})\)")
+
+RATE_LIMIT_STATUS = 509
+RETRYABLE_STATUSES = (502, 503)
+
+_BASE_BACKOFF = 60.0
+_MAX_BACKOFF = 600.0
+
+# Module-level (not per-coordinator) state: a 509 from one station's poll
+# should also pause polling for other stations, since MVG's rate limit is
+# presumably per client/IP, not per station.
+_rate_limited_until = 0.0
+_rate_limit_backoff = _BASE_BACKOFF
+
+
+def _extract_status_code(exc: MvgApiError) -> int | None:
+    """Extract the HTTP status code from an MvgApiError's message, if any."""
+    match = _STATUS_RE.search(str(exc))
+    return int(match.group(1)) if match else None
+
+
+async def call_with_resilience(
+    factory: Callable[[], Coroutine[Any, Any, T]],
+    *,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+) -> T:
+    """Call an mvg API coroutine factory with retry, backoff and rate-limit handling.
+
+    :param factory: a callable producing a fresh coroutine on each call (a coroutine
+        object can only be awaited once, so a factory is needed for retries)
+    :param max_retries: number of retries for transient errors (502/503, network errors)
+    :param base_delay: base delay in seconds for the exponential retry backoff
+    :raises MvgApiError: if the call keeps failing, or a rate-limit cooldown is active
+    """
+    global _rate_limited_until, _rate_limit_backoff
+
+    if time.monotonic() < _rate_limited_until:
+        raise MvgApiError("MVG API is rate limited, skipping call until backoff expires")
+
+    for attempt in range(max_retries + 1):
+        try:
+            result = await factory()
+        except MvgApiError as exc:
+            status = _extract_status_code(exc)
+
+            if status == RATE_LIMIT_STATUS:
+                _rate_limited_until = time.monotonic() + _rate_limit_backoff
+                _rate_limit_backoff = min(_rate_limit_backoff * 2, _MAX_BACKOFF)
+                _LOGGER.warning(
+                    "MVG API rate limit hit, backing off for %.0f seconds", _rate_limit_backoff
+                )
+                raise
+
+            if (status in RETRYABLE_STATUSES or status is None) and attempt < max_retries:
+                delay = base_delay * (2**attempt) + random.uniform(0, 1)
+                _LOGGER.debug("MVG API call failed (%s), retrying in %.1fs", exc, delay)
+                await asyncio.sleep(delay)
+                continue
+
+            raise
+        else:
+            _rate_limit_backoff = _BASE_BACKOFF
+            return result
+
+    raise AssertionError("unreachable")  # loop always returns or raises

--- a/custom_components/mvg/coordinator.py
+++ b/custom_components/mvg/coordinator.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from mvg import MvgApi, MvgApiError, TransportType
+from mvg import MvgApi, TransportType
 
+from .api_resilience import call_with_resilience
 from .const import DOMAIN, SCAN_INTERVAL
 from .messages import fetch_incident_messages
 
@@ -48,18 +49,40 @@ class MvgDataUpdateCoordinator(DataUpdateCoordinator[MvgData]):
         )
 
     async def _async_update_data(self) -> MvgData:
-        """Fetch departures and incident messages from the MVG API."""
-        try:
-            departures, messages = await asyncio.gather(
-                MvgApi.departures_async(
+        """Fetch departures and incident messages from the MVG API.
+
+        Departures and messages are treated independently: a failure fetching one
+        doesn't blank out the other. If a previous successful poll exists, its data
+        is kept as a fallback; only a departures failure on the very first refresh
+        (no fallback data available) fails the whole update.
+        """
+        previous = self.data
+
+        departures_result, messages_result = await asyncio.gather(
+            call_with_resilience(
+                lambda: MvgApi.departures_async(
                     station_id=self._station_id,
                     limit=self._number,
                     offset=self._timeoffset,
                     transport_types=self._transport_types,
-                ),
-                fetch_incident_messages(),
-            )
-        except MvgApiError as exc:
-            raise UpdateFailed(f"Error communicating with MVG API: {exc}") from exc
+                )
+            ),
+            call_with_resilience(fetch_incident_messages),
+            return_exceptions=True,
+        )
+
+        if isinstance(departures_result, BaseException):
+            _LOGGER.warning("Could not update MVG departures: %s", departures_result)
+            if previous is None:
+                raise UpdateFailed(f"Error fetching departures: {departures_result}") from departures_result
+            departures = previous.departures
+        else:
+            departures = departures_result
+
+        if isinstance(messages_result, BaseException):
+            _LOGGER.warning("Could not update MVG incident messages: %s", messages_result)
+            messages = previous.messages if previous is not None else []
+        else:
+            messages = messages_result
 
         return MvgData(departures=departures, messages=messages)

--- a/custom_components/mvg/manifest.json
+++ b/custom_components/mvg/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mvg",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "name": "MVG",
   "codeowners": [],
   "config_flow": true,


### PR DESCRIPTION
## Summary

Adds retry, backoff and rate-limit handling around the mvg package's API calls, adapted from the ideas explored in feature-error-handling (never merged, targeted the old vendored API client that has since been replaced by the real mvg PyPI package).

- Retry with exponential backoff on transient errors (HTTP 502/503, network errors), up to 3 attempts, with jitter.
- Rate-limit cooldown on HTTP 509: MVG returns this when polled too aggressively. On a 509, further API calls are paused for a backoff period that starts at 60s and doubles up to a 600s cap, resetting after the next successful call. This state is global (not per-station), since the rate limit is presumably per client/IP rather than per station.
- Independent error handling for departures and messages: a failure fetching one no longer blanks out the other. If a previous successful poll exists, its data is kept as a fallback instead of clearing the sensor; only a departures failure on the very first refresh (no fallback data yet) fails the update and marks the entity unavailable.

## Implementation notes

- New custom_components/mvg/api_resilience.py: call_with_resilience() wraps any mvg API coroutine factory with the retry/backoff/cooldown logic described above. Since the mvg package only exposes failures as a plain-text MvgApiError (no structured status code), the HTTP status is extracted from the error message via regex.
- custom_components/mvg/coordinator.py: _async_update_data() now fetches departures and messages via call_with_resilience() using asyncio.gather(..., return_exceptions=True), and falls back to the previous coordinator data per data source on failure instead of failing the whole update.